### PR TITLE
Fix: Handle deprecated Dimensions.removeEventListener crash

### DIFF
--- a/lib/toast/ToastView.js
+++ b/lib/toast/ToastView.js
@@ -37,7 +37,8 @@ export default class ToastView extends Component{
             this.liftCycleAnimated.stop()
             this.liftCycleAnimated = undefined
         }
-        Dimensions.removeEventListener('change', this.onWindowChange);
+        if(Dimensions?.remove) Dimensions.remove();
+        if(Dimensions?.removeEventListener) Dimensions.removeEventListener('change', this.onWindowChange); // Legacy
     }
 
     render() {


### PR DESCRIPTION
_**Problem:**_
The app was crashing with the following error:

```
TypeError: _reactNative.Dimensions.removeEventListener is not a function.
(In '_reactNative.Dimensions.removeEventListener('change', this.onWindowChange)', '_reactNative.Dimensions.removeEventListener' is undefined)
```
![Simulator Screenshot - iPhone 15 Pro - 2024-12-07 at 10 46 57](https://github.com/user-attachments/assets/20e71c5a-162f-4dd9-9f01-350622ed7855)

This is due to Dimensions.removeEventListener being deprecated and removed in newer versions of React Native (post v0.65). The legacy usage of removeEventListener causes crashes in React Native projects using newer versions.

**_Solution_**
The fix ensures compatibility with both legacy and newer React Native versions. The updated code uses a conditional approach to clean up event listeners based on the available API.

_**Testing**_

- Verified the fix on React Native 0.65+ (no crash, Dimensions.remove works).
- Verified compatibility with React Native 0.64 and older (fallback to removeEventListener works without issues).

**_Why this is important_**
This fix ensures backward compatibility and prevents the app from crashing due to breaking API changes in React Native. It provides a graceful transition for projects gradually upgrading React Native versions, 
you have a nice package here, thanks for what you do!
